### PR TITLE
Add LangGraph agent integration

### DIFF
--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -49,7 +49,12 @@ async def process_step(
         response["ending"] = final_state["ending"]["ending"]
         response["game_over"] = True
     else:
-        current_scene = final_state.get("scene")
+        # Берём актуальную сцену из состояния пользователя,
+        # чтобы гарантировать наличие сгенерированных ассетов
+        if user_state.current_scene_id and user_state.current_scene_id in user_state.scenes:
+            current_scene = user_state.scenes[user_state.current_scene_id].dict()
+        else:
+            current_scene = final_state.get("scene")
         response["scene"] = current_scene
         response["game_over"] = False
         # Для UI: можно вернуть пути до ассетов, варианты, текст сцены и пр.


### PR DESCRIPTION
## Summary
- integrate LangGraph agent runner with UI
- implement scene retrieval from user state
- start games via graph and update scenes through graph responses

## Testing
- `python -m py_compile src/main.py src/game_constructor.py src/agent/runner.py`
- `pip install langgraph`
- `python src/test.py` *(fails: ModuleNotFoundError: No module named 'google.api_core')*


------
https://chatgpt.com/codex/tasks/task_e_683f47c864f883288159a0a8dd4cb6f5