### PR TITLE
Improve graph state handling and logging

### DIFF
--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -20,12 +20,14 @@ async def process_step(
     - step: "choose" — пользователь делает выбор
     """
     logger.info(f"[Runner] Step: {step}, user: {user_hash}")
+    logger.debug(f"[Runner] Building graph_state for {user_hash}: step={step}")
 
     # Формируем начальное состояние для графа
     graph_state = {
         "user_hash": user_hash,
         "step": step,
     }
+    logger.debug(f"[Runner] Initial graph_state: {graph_state}")
     if step == "start":
         assert setting and character and genre, "Необходимы setting, character, genre"
         graph_state.update({
@@ -39,17 +41,25 @@ async def process_step(
 
     # Запускаем граф (асинхронно, один проход)
     async for final_state in llm_game_graph.astream(graph_state):
-            pass
+        logger.debug(f"[Runner] Intermediate state: {final_state}")
+        pass
 
     # Возвращаем всё нужное для UI (сцена, варианты, ассеты, ending)
     user_state: UserState = get_user_state(user_hash)
     response = {}
 
+    logger.debug(f"[Runner] Final state after graph: {final_state}")
+
     if final_state.get("ending", {}).get("ending_reached"):
         response["ending"] = final_state["ending"]["ending"]
         response["game_over"] = True
     else:
-        current_scene = final_state.get("scene")
+        # Берём актуальную сцену из состояния пользователя,
+        # чтобы гарантировать наличие сгенерированных ассетов
+        if user_state.current_scene_id and user_state.current_scene_id in user_state.scenes:
+            current_scene = user_state.scenes[user_state.current_scene_id].dict()
+        else:
+            current_scene = final_state.get("scene")
         response["scene"] = current_scene
         response["game_over"] = False
         # Для UI: можно вернуть пути до ассетов, варианты, текст сцены и пр.


### PR DESCRIPTION
## Summary
- add debug logs in runner and graph
- convert graph state to dataclass and use async tool execution

## Testing
- `python -m py_compile src/main.py src/game_constructor.py src/agent/runner.py src/agent/llm_graph.py`
- `python src/test.py` *(fails: ImportError: cannot import name 'genai' from 'google')*

------
https://chatgpt.com/codex/tasks/task_e_683f47c864f883288159a0a8dd4cb6f5