### PR TITLE
Fix structured LLM responses

### DIFF
--- a/src/agent/models.py
+++ b/src/agent/models.py
@@ -24,6 +24,15 @@ class StoryFrame(BaseModel):
     genre: str
 
 
+class StoryFrameLLM(BaseModel):
+    """Output structure returned by the LLM for story frame generation."""
+    lore: str
+    goal: str
+    milestones: List[Milestone]
+    endings: List[Ending]
+
+
+
 class SceneChoice(BaseModel):
     text: str
     next_scene_short_desc: str
@@ -35,6 +44,18 @@ class Scene(BaseModel):
     choices: List[SceneChoice]
     image: Optional[str] = None
     music: Optional[str] = None
+
+
+class SceneLLM(BaseModel):
+    """Structure expected from the LLM when generating a scene."""
+    description: str
+    choices: List[SceneChoice]
+
+
+class EndingCheckResult(BaseModel):
+    """Result returned from the LLM when checking for an ending."""
+    ending_reached: bool = Field(default=False)
+    ending: Optional[Ending] = None
 
 
 class UserChoice(BaseModel):

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -8,6 +8,7 @@ Genre: {genre}
 - goal: основная цель игрока
 - milestones: 2-4 важных события (id, description)
 - endings: good/bad endings (id, type, condition, description)
+Отвечай ТОЛЬКО JSON без пояснений.
 """
 
 SCENE_PROMPT = """
@@ -20,6 +21,7 @@ Endings: {endings}
 Сгенерируй новую сцену в формате:
 - description: короткое описание ситуации
 - choices: список из 2-3 dict {"text": ..., "next_scene_short_desc": ...}
+Отвечай ТОЛЬКО JSON без пояснений.
 """
 
 ENDING_CHECK_PROMPT = """
@@ -27,4 +29,5 @@ Milestones achieved: {milestones}
 Endings: {endings}
 Проверь, выполнены ли условия концовки. Если да, верни ending_reached: true и ending (id, type, description).
 Если нет — ending_reached: false.
+Отвечай ТОЛЬКО JSON без пояснений.
 """

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -20,12 +20,14 @@ async def process_step(
     - step: "choose" — пользователь делает выбор
     """
     logger.info(f"[Runner] Step: {step}, user: {user_hash}")
+    logger.debug(f"[Runner] Building graph_state for {user_hash}: step={step}")
 
     # Формируем начальное состояние для графа
     graph_state = {
         "user_hash": user_hash,
         "step": step,
     }
+    logger.debug(f"[Runner] Initial graph_state: {graph_state}")
     if step == "start":
         assert setting and character and genre, "Необходимы setting, character, genre"
         graph_state.update({
@@ -39,17 +41,25 @@ async def process_step(
 
     # Запускаем граф (асинхронно, один проход)
     async for final_state in llm_game_graph.astream(graph_state):
-            pass
+        logger.debug(f"[Runner] Intermediate state: {final_state}")
+        pass
 
     # Возвращаем всё нужное для UI (сцена, варианты, ассеты, ending)
     user_state: UserState = get_user_state(user_hash)
     response = {}
 
+    logger.debug(f"[Runner] Final state after graph: {final_state}")
+
     if final_state.get("ending", {}).get("ending_reached"):
         response["ending"] = final_state["ending"]["ending"]
         response["game_over"] = True
     else:
-        current_scene = final_state.get("scene")
+        # Берём актуальную сцену из состояния пользователя,
+        # чтобы гарантировать наличие сгенерированных ассетов
+        if user_state.current_scene_id and user_state.current_scene_id in user_state.scenes:
+            current_scene = user_state.scenes[user_state.current_scene_id].dict()
+        else:
+            current_scene = final_state.get("scene")
         response["scene"] = current_scene
         response["game_over"] = False
         # Для UI: можно вернуть пути до ассетов, варианты, текст сцены и пр.


### PR DESCRIPTION
## Summary
- parse LLM outputs using pydantic models
- enforce JSON-only answers in prompts
- support structured scene and ending results in tools

## Testing
- `python -m py_compile src/main.py src/game_constructor.py src/agent/runner.py src/agent/llm_graph.py src/agent/tools.py src/agent/models.py src/agent/prompts.py`
- `pip install langgraph`
- `python src/test.py` *(fails: ImportError: cannot import name 'genai' from 'google')*


------
https://chatgpt.com/codex/tasks/task_e_683f47c864f883288159a0a8dd4cb6f5