### PR TITLE
Fix processing of final graph state

### DIFF
--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -1,6 +1,7 @@
 from agent.llm_graph import llm_game_graph, GraphState
 from agent.state import get_user_state
 from agent.models import UserState
+from dataclasses import asdict
 import logging
 
 logger = logging.getLogger(__name__)
@@ -37,10 +38,8 @@ async def process_step(
         assert choice_text, "Необходимо choice_text"
         graph_state.choice_text = choice_text
 
-    # Запускаем граф (асинхронно, один проход)
-    async for final_state in llm_game_graph.astream(graph_state):
-        logger.debug(f"[Runner] Intermediate state: {final_state}")
-        pass
+    # Запускаем граф и получаем финальное состояние
+    final_state = await llm_game_graph.ainvoke(asdict(graph_state))
 
     # Возвращаем всё нужное для UI (сцена, варианты, ассеты, ending)
     user_state: UserState = get_user_state(user_hash)
@@ -48,8 +47,9 @@ async def process_step(
 
     logger.debug(f"[Runner] Final state after graph: {final_state}")
 
-    if final_state.ending and final_state.ending.get("ending_reached"):
-        response["ending"] = final_state.ending["ending"]
+    ending = final_state.get("ending")
+    if ending and ending.get("ending_reached"):
+        response["ending"] = ending["ending"]
         response["game_over"] = True
     else:
         # Берём актуальную сцену из состояния пользователя,
@@ -57,7 +57,7 @@ async def process_step(
         if user_state.current_scene_id and user_state.current_scene_id in user_state.scenes:
             current_scene = user_state.scenes[user_state.current_scene_id].dict()
         else:
-            current_scene = final_state.scene
+            current_scene = final_state.get("scene")
         response["scene"] = current_scene
         response["game_over"] = False
         # Для UI: можно вернуть пути до ассетов, варианты, текст сцены и пр.


### PR DESCRIPTION
## Summary
- use ainvoke instead of astream in `process_step`
- handle final state as a dict

## Testing
- `python -m py_compile src/agent/runner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684021c4c61483289445011ab6cb664f