### PR TITLE
Fix ending scene image

### DIFF
--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -3,6 +3,10 @@
 import logging
 from dataclasses import asdict
 from typing import Dict, Optional
+import uuid
+
+from agent.image_agent import generate_image_prompt
+from agent.tools import generate_scene_image
 
 from agent.llm_graph import GraphState, llm_game_graph
 from agent.models import UserState
@@ -41,15 +45,24 @@ async def process_step(
     if ending and ending.get("ending_reached"):
         ending_info = ending["ending"]
         if (
-            ("description" not in ending_info
-                or not ending_info["description"])
+            ("description" not in ending_info or not ending_info["description"])
             and user_state.story_frame
         ):
             for e in user_state.story_frame.endings:
                 if e.id == ending_info.get("id"):
                     ending_info["description"] = e.description
                     break
+
+        ending_desc = ending_info.get("description") or ending_info.get("condition", "")
+        change_scene = await generate_image_prompt(ending_desc, user_hash)
+        image_path = await generate_scene_image(
+            user_hash=user_hash,
+            scene_id=f"ending_{uuid.uuid4()}",
+            change_scene=change_scene,
+        )
+
         response["ending"] = ending_info
+        response["image"] = image_path
         response["game_over"] = True
     else:
         if (

--- a/src/main.py
+++ b/src/main.py
@@ -54,10 +54,13 @@ async def update_scene(user_hash: str, choice):
 
     if result.get("game_over"):
         ending = result["ending"]
-        ending_text = ending.get("description") or ending.get("condition", "")
+        ending_text = (
+            ending.get("description") or ending.get("condition", "")
+        ) + "\n[THE END]"
+        ending_image = result.get("image")
         return (
             gr.update(value=ending_text),
-            gr.update(value=None),
+            gr.update(value=ending_image),
             gr.Radio(choices=[], label="", value=None, visible=False),
             gr.update(value="", visible=False),
         )


### PR DESCRIPTION
## Summary
- show the last scene image on game over
- generate an image for the ending description
- mark the story ending with `[THE END]`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684466fa8e6883288d6e255d0bb73ed9